### PR TITLE
Add student profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ npm install
 npm run dev
 ```
 
-The site includes pages for projects, success stories, community discussions, and career listings.
+The site includes pages for projects, success stories, community discussions, career listings, and student profiles.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Projects from './pages/Projects'
 import SuccessStories from './pages/SuccessStories'
 import Community from './pages/Community'
 import Careers from './pages/Careers'
+import Profile from './pages/Profile'
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
             <Route path="/success-stories" element={<SuccessStories />} />
             <Route path="/community" element={<Community />} />
             <Route path="/careers" element={<Careers />} />
+            <Route path="/profile" element={<Profile />} />
           </Routes>
         </main>
         <Footer />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -10,6 +10,7 @@ function Navbar() {
           <Link to="/success-stories" className="hover:underline">Success Stories</Link>
           <Link to="/community" className="hover:underline">Community</Link>
           <Link to="/careers" className="hover:underline">Careers</Link>
+          <Link to="/profile" className="hover:underline">Profile</Link>
         </div>
       </div>
     </nav>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,0 +1,132 @@
+import { useState } from 'react'
+
+function Profile() {
+  const [profile, setProfile] = useState({
+    name: '',
+    location: '',
+    phone: '',
+    interests: '',
+    bio: '',
+    education: '',
+    experience: '',
+  })
+  const [photo, setPhoto] = useState(null)
+
+  function handleChange(e) {
+    const { name, value } = e.target
+    setProfile((prev) => ({ ...prev, [name]: value }))
+  }
+
+  function handlePhotoChange(e) {
+    const file = e.target.files[0]
+    if (file) {
+      setPhoto(URL.createObjectURL(file))
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-4">Your Profile</h1>
+      <form className="space-y-4">
+        <div>
+          <label className="block font-semibold mb-1">Profile Photo</label>
+          {photo && (
+            <img
+              src={photo}
+              alt="Profile preview"
+              className="h-32 w-32 object-cover rounded-full mb-2"
+            />
+          )}
+          <input type="file" accept="image/*" onChange={handlePhotoChange} />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Name</label>
+          <input
+            className="border rounded p-2 w-full"
+            name="name"
+            value={profile.name}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Location</label>
+          <input
+            className="border rounded p-2 w-full"
+            name="location"
+            value={profile.location}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Phone</label>
+          <input
+            className="border rounded p-2 w-full"
+            name="phone"
+            value={profile.phone}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Interests</label>
+          <input
+            className="border rounded p-2 w-full"
+            name="interests"
+            value={profile.interests}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Bio</label>
+          <textarea
+            className="border rounded p-2 w-full"
+            name="bio"
+            rows="3"
+            value={profile.bio}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Education</label>
+          <textarea
+            className="border rounded p-2 w-full"
+            name="education"
+            rows="3"
+            value={profile.education}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Experience</label>
+          <textarea
+            className="border rounded p-2 w-full"
+            name="experience"
+            rows="3"
+            value={profile.experience}
+            onChange={handleChange}
+          />
+        </div>
+      </form>
+      <div className="mt-8">
+        <h2 className="text-2xl font-bold mb-2">Preview</h2>
+        {photo && (
+          <img
+            src={photo}
+            alt="Profile preview"
+            className="h-32 w-32 object-cover rounded-full mb-2"
+          />
+        )}
+        <p className="font-semibold">{profile.name}</p>
+        <p>{profile.location}</p>
+        <p>{profile.phone}</p>
+        <p>{profile.interests}</p>
+        <p className="mt-2 whitespace-pre-line">{profile.bio}</p>
+        <h3 className="font-semibold mt-4">Education</h3>
+        <p className="whitespace-pre-line">{profile.education}</p>
+        <h3 className="font-semibold mt-4">Experience</h3>
+        <p className="whitespace-pre-line">{profile.experience}</p>
+      </div>
+    </div>
+  )
+}
+
+export default Profile


### PR DESCRIPTION
## Summary
- create a `Profile` page where students can enter personal and resume information
- link the new page in the navbar
- add a new route in `App.jsx`
- document the profile page in the README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68709f28432c8320a3ca30fbf81cd8a2

## Summary by Sourcery

Add a student Profile page for entering and previewing personal and resume information, integrate it into the navigation and application routes, and update documentation.

New Features:
- Introduce a Profile page at "/profile" with form inputs for photo, name, location, phone, interests, bio, education, and experience along with a live preview.

Enhancements:
- Add a Profile link in the navbar and configure the corresponding route in App.jsx.

Documentation:
- Update README to mention the newly added student profiles page.